### PR TITLE
♻️ (podcasts-container.component.ts, podcast.service.ts, podcast.stor…

### DIFF
--- a/src/app/components/podcasts/podcasts-container.component.ts
+++ b/src/app/components/podcasts/podcasts-container.component.ts
@@ -11,7 +11,6 @@ import { PodcastItemComponent } from './podcast-item/podcast-item.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @let podcasts = store.podcasts();
-    <!-- YEP::  {{podcasts | json }} -->
     @defer (when podcasts) {
       <h2
         class="text-2xl font-semibold text-center text-gray-800 capitalize lg:text-3xl dark:text-white"

--- a/src/app/services/podcasts/podcast.service.ts
+++ b/src/app/services/podcasts/podcast.service.ts
@@ -18,11 +18,9 @@ export class PodcastService {
   }
 
   getMyPodcasts() {
-    return toSignal(
-      this.apiService
-        .get<Broadcast[]>(`${this.PATH}/myPodcasts`)
-        .pipe(map(PodcastAdapter)),
-    );
+    return this.apiService
+      .get<Broadcast[]>(`/myPodcasts`)
+      .pipe(map(PodcastAdapter));
   }
 
   getAll() {

--- a/src/app/store/podcast.store.ts
+++ b/src/app/store/podcast.store.ts
@@ -34,16 +34,6 @@ export const PodcastStore = signalStore(
   { providedIn: 'root' },
   withState(() => inject(STORE_STATE)),
   withEntities<Podcast>(),
-  withMethods((store, podcastService = inject(PodcastService)) => ({
-    async getAllPodcasts() {
-      patchState(store, { loading: true });
-      const allPodcasts = await lastValueFrom(podcastService.getAll());
-      patchState(store, { podcasts: allPodcasts, loading: false });
-    },
-    getMyPodcasts() {
-      return podcastService.getMyPodcasts();
-    },
-  })),
   withComputed(({ podcasts, myPodcasts, filter }) => ({
     subscribedPodcasts: computed(() =>
       podcasts().filter((podcast) =>
@@ -55,9 +45,23 @@ export const PodcastStore = signalStore(
       return podcasts().sort((a, b) => (a.rating - b.rating) * direction);
     }),
   })),
+  withMethods((store, podcastService = inject(PodcastService)) => ({
+    async getAllPodcasts() {
+      patchState(store, { loading: true });
+      const allPodcasts = await lastValueFrom(podcastService.getAll());
+      patchState(store, { podcasts: allPodcasts, loading: false });
+    },
+    async getMyPodcasts() {
+      patchState(store, { loading: true });
+      const pods = await lastValueFrom(podcastService.getMyPodcasts());
+      patchState(store, { myPodcasts: pods, loading: false });
+    },
+  })),
+
   withHooks({
     async onInit(store) {
       store.getAllPodcasts();
+      store.getMyPodcasts();
     },
   }),
 );


### PR DESCRIPTION
…e.ts): Refactor podcast fetching and state management

- Removed debug code from `podcasts-container.component.ts` to clean up the template.
- Simplified the `getMyPodcasts` method in `podcast.service.ts` by removing unnecessary wrapping with `toSignal`, streamlining the API call.
- Reorganized `PodcastStore` in `podcast.store.ts` by moving `withMethods` to the bottom for better readability and consistency. Also, updated `getMyPodcasts` to be asynchronous and manage loading state, aligning it with the `getAllPodcasts` method for consistency in how podcast data is fetched and state is managed.

These changes improve code maintainability by ensuring consistency in state management practices across the application and removing unnecessary complexity in service calls. Additionally, cleaning up the debug code in the component template enhances the clarity of the codebase.