### PR TITLE
📝 (01-to-signal.md): fix punctuation in article conclusion

### DIFF
--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -53,4 +53,4 @@ In the template, we can directly use episodes() to access the latest value, just
 
 #Angular #WebDevelopment #JavaScript #RxJS #FrontendDevelopment
 
-What do you think? Want to dive deeper into Signals and RxJS integration? Let me know in the comments!
+What do you think? Want to dive deeper into Signals and RxJS integration? Let me know in the comments!.


### PR DESCRIPTION
Add a missing period at the end of the sentence to improve grammatical correctness and maintain consistency in the article's formatting.