### PR TITLE
📝 (01-to-signal.md): update cover image format from jpg to png for be…

### DIFF
--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -58,6 +58,6 @@ We're fetching data from an API, transforming it with EpisodeAdapter, and then w
 In the template, we can directly use episodes() to access the latest value, just like any other Signal!
 ⚠️ Important Note: The RxJS Interop package (`@angular/core/rxjs-interop`) is currently available for developer preview. While it's ready for experimentation, be aware that it might undergo changes before reaching a stable release.
 
-🚀 Ready to level up your Angular skills? Start experimenting with `toSignal` in your projects today!
+🚀 Ready to level up your Angular skills? Start experimenting with `toSignal` in your projects today!!
 
 What do you think? Want to dive deeper into Signals and RxJS integration? Let me know in the comments!.

--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -3,7 +3,7 @@ title: New in Angular Bridging RxJS and Signals with `toSignal`! 🚀
 published: false
 description: Angular developers, are you ready to simplify your reactive programming? Let me introduce you to `toSignal`, a game-changing feature that seamlessly connects RxJS Observables with Angular's new Signals API.
 tags: 'Angular, RxJS, Signals, Web Development, Programming'
-cover_image: ./assets/to-signal.jpg
+cover_image: ./assets/to-signal.png
 canonical_url: null
 ---
 

--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -7,8 +7,6 @@ cover_image: ./assets/to-signal.png
 canonical_url: null
 ---
 
-# [New in Angular: Bridging RxJS and Signals with `toSignal`! 🚀](https://www.linkedin.com/pulse/new-angular-bridging-rxjs-signals-tosignal-jes%C3%BAs-bened%C3%A9-gxsef/?trackingId=6aC5rZqkTD%2B5UP8T%2B0tHeQ%3D%3D)
-
 Angular developers, are you ready to simplify your reactive programming? Let me introduce you to `toSignal`, a game-changing feature that seamlessly connects RxJS Observables with Angular's new Signals API.
 
 🔗 What is `toSignal`?


### PR DESCRIPTION
…tter quality

The cover image format is changed from JPG to PNG to improve image quality. PNG format is generally better for images with text and graphics, providing clearer visuals, which enhances the article's presentation.