### PR TITLE
🔧 (dev-publisher.yml): downgrade publish-devto action to v1 for compa…

### DIFF
--- a/.github/workflows/dev-publisher.yml
+++ b/.github/workflows/dev-publisher.yml
@@ -23,7 +23,7 @@
             fi
 
         - name: Publish articles to Dev.to
-          uses: sinedied/publish-devto@v1
+          uses: sinedied/publish-devto@v2
           with:
             devto_key: ${{ secrets.DEVTO }}
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-publisher.yml
+++ b/.github/workflows/dev-publisher.yml
@@ -23,7 +23,7 @@
             fi
 
         - name: Publish articles to Dev.to
-          uses: sinedied/publish-devto@v2
+          uses: sinedied/publish-devto@v1
           with:
             devto_key: ${{ secrets.DEVTO }}
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-publisher.yml
+++ b/.github/workflows/dev-publisher.yml
@@ -25,7 +25,7 @@
         - name: Publish articles to Dev.to
           uses: sinedied/publish-devto@v2
           with:
-            devto_key: ${{ secrets.DEVTO }}
+            devto_key: ${{ secrets.DEVTO_TOKEN }}
             github_token: ${{ secrets.GITHUB_TOKEN }}
             files: "articles/**/*.md"
             conventional_commits: true

--- a/articles/00-test.md
+++ b/articles/00-test.md
@@ -2,4 +2,5 @@
 title: 'How Angular Routing Works'
 date: '2024-11-12'
 tags: ['Angular', 'Routing', 'JavaScript', 'Web Development']
+published: true
 ---


### PR DESCRIPTION
…tibility

📝 (00-test.md): set article to published status

The GitHub Action for publishing articles to Dev.to is downgraded from v2 to v1 to address compatibility issues or bugs encountered with the newer version. The article "How Angular Routing Works" is marked as published to ensure it is visible on the platform.