### PR TITLE
🔧 (dev-publisher.yml): add permissions to allow bot to update posts o…

### DIFF
--- a/.github/workflows/dev-publisher.yml
+++ b/.github/workflows/dev-publisher.yml
@@ -9,6 +9,8 @@
   jobs:
     publish:
       runs-on: ubuntu-latest
+      permissions:
+        contents: write # this lets the bot update the post in github
       steps:
         - name: Checkout code
           uses: actions/checkout@v4


### PR DESCRIPTION
…n GitHub

The permissions section is added to the GitHub Actions workflow to grant the necessary write access to the contents. This change is essential for enabling the bot to update posts on GitHub, ensuring that the workflow can perform its intended publishing tasks without permission issues.