### PR TITLE
🔧 (dev-publisher.yml): update workflow permissions and environment va…

### DIFF
--- a/.github/workflows/dev-publisher.yml
+++ b/.github/workflows/dev-publisher.yml
@@ -6,6 +6,9 @@
         - "**"
       paths:
         - "articles/**/*.md"
+  permissions:
+    contents: write
+
   jobs:
     publish:
       runs-on: ubuntu-latest
@@ -32,3 +35,11 @@
             files: "articles/**/*.md"
             conventional_commits: true
             dry_run: ${{ env.dry_run }}
+          env:
+            GIT_COMMITTER_NAME: ${{ github.actor }}
+            GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+
+        - name: Publish result
+          run: |
+            echo "Publishing Result: ${{ steps.publish_articles.outputs.result_json }}"
+          continue-on-error: true


### PR DESCRIPTION
…riables

Add 'contents: write' permission to allow the workflow to modify repository contents. Set GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL environment variables to ensure commits are attributed to the GitHub actor. Add a step to publish the result and continue on error to provide feedback on the publishing process.

These changes enhance the workflow's ability to manage content publishing and ensure proper attribution of commits, while also providing feedback on the publishing process.