### PR TITLE
📝 (01-to-signal.md): add front matter metadata for article configuration

### DIFF
--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -1,3 +1,12 @@
+---
+title: 'Simplify Angular Reactive Programming with toSignal'
+published: false
+description: 'Learn how to simplify your Angular reactive programming by using the toSignal function to connect RxJS Observables with Angular Signals API.
+tags: 'Angular, RxJS, Signals, reactive programming, toSignal'
+series: 'Angular Development'
+cover_image: ./assets/to-signal.png
+---
+
 Angular developers, are you ready to simplify your reactive programming? Let me introduce you to `toSignal`, a game-changing feature that seamlessly connects RxJS Observables with Angular's new Signals API.
 
 🔗 What is `toSignal`?

--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -1,9 +1,9 @@
 ---
 title: 'Simplify Angular Reactive Programming with toSignal'
 published: false
-description: 'Learn how to simplify your Angular reactive programming by using the toSignal function to connect RxJS Observables with Angular Signals API.
+description: 'Learn how to simplify your Angular reactive programming by using the toSignal function to connect RxJS Observables with Angular Signals API.'
 tags: 'Angular, RxJS, Signals, reactive programming, toSignal'
-series: Angular Development
+series: Angular development
 cover_image: ./assets/to-signal.png
 ---
 

--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -3,7 +3,7 @@ title: 'Simplify Angular Reactive Programming with toSignal'
 published: false
 description: 'Learn how to simplify your Angular reactive programming by using the toSignal function to connect RxJS Observables with Angular Signals API.
 tags: 'Angular, RxJS, Signals, reactive programming, toSignal'
-series: 'Angular Development'
+series: Angular Development
 cover_image: ./assets/to-signal.png
 ---
 


### PR DESCRIPTION
Add front matter metadata to the article to provide essential information such as title, publication status, description, tags, series, and cover image. This metadata is crucial for content management systems to correctly display and categorize the article, enhancing discoverability and organization.