### PR TITLE
📝 (01-to-signal.md): remove 'series' metadata from article front matter

### DIFF
--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -3,7 +3,6 @@ title: 'Simplify Angular Reactive Programming with toSignal'
 published: false
 description: 'Unleash the power of toSignal'
 tags: 'Angular, RxJS, Signals, reactive programming, toSignal'
-series: Angular development
 cover_image: ./assets/to-signal.png
 ---
 


### PR DESCRIPTION
The 'series' metadata is removed from the article front matter to simplify the metadata structure. This change is made because the article is not part of a series, and removing unnecessary metadata helps maintain clarity and focus in the document.