### PR TITLE
📝 (01-to-signal.md): update article metadata for improved clarity

### DIFF
--- a/articles/01-to-signal.md
+++ b/articles/01-to-signal.md
@@ -2,8 +2,7 @@
 title: 'Simplify Angular Reactive Programming with toSignal'
 published: false
 description: 'Unleash the power of toSignal'
-tags: 'Angular, RxJS, Signals, reactive programming, toSignal'
-cover_image: ./assets/to-signal.png
+tags: 'Angular, RxJS, Signals, Reactive Programming'
 ---
 
 Angular developers, are you ready to simplify your reactive programming? Let me introduce you to `toSignal`, a game-changing feature that seamlessly connects RxJS Observables with Angular's new Signals API.


### PR DESCRIPTION
Remove the 'toSignal' tag as it is redundant and update the tags to ensure consistency in capitalization. The 'cover_image' field is removed to streamline the metadata, possibly due to the image being unnecessary or unavailable. These changes enhance the clarity and relevance of the article's metadata.