### PR TITLE
📝 (17-testing-in-angular.md): remove redundant tag from article metadata

### DIFF
--- a/articles/17-testing-in-angular.md
+++ b/articles/17-testing-in-angular.md
@@ -2,7 +2,7 @@
 title: 'Modern Testing Practices in Angular: From Unit to Integration Testing'
 published: false
 description: 'Learn about the shift from unit to integration testing in Angular'
-tags: 'angular, unit testing, integration testing, testing'
+tags: 'angular, unit testing, integration testing'
 cover_image: ./assets/ng-testing.png
 ---
 


### PR DESCRIPTION
The 'testing' tag is removed from the article metadata as it is redundant. The tags 'unit testing' and 'integration testing' already cover the testing aspect, making the 'testing' tag unnecessary. This change helps in maintaining a more focused and relevant tagging system.